### PR TITLE
[For Info] Some minor tweaks to ELF hooking

### DIFF
--- a/plthook.h
+++ b/plthook.h
@@ -51,6 +51,7 @@ extern "C" {
 #endif
 
 int plthook_open(plthook_t **plthook_out, const char *filename);
+int plthook_open_by_handle(plthook_t **plthook_out, void *handle);
 int plthook_open_by_address(plthook_t **plthook_out, void *address);
 int plthook_enum(plthook_t *plthook, unsigned int *pos, const char **name_out, void ***addr_out);
 int plthook_replace(plthook_t *plthook, const char *funcname, void *funcaddr, void **oldfunc);

--- a/plthook.h
+++ b/plthook.h
@@ -46,11 +46,19 @@
 
 typedef struct plthook plthook_t;
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 int plthook_open(plthook_t **plthook_out, const char *filename);
 int plthook_open_by_address(plthook_t **plthook_out, void *address);
 int plthook_enum(plthook_t *plthook, unsigned int *pos, const char **name_out, void ***addr_out);
 int plthook_replace(plthook_t *plthook, const char *funcname, void *funcaddr, void **oldfunc);
 void plthook_close(plthook_t *plthook);
 const char *plthook_error(void);
+
+#ifdef __cplusplus
+}; /* extern "C" */
+#endif
 
 #endif

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -176,6 +176,21 @@ int plthook_open(plthook_t **plthook_out, const char *filename)
     }
 }
 
+int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
+{
+    struct link_map *lmap = NULL;
+
+    if (hndl == NULL) {
+        set_errmsg("NULL handle");
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    if (dlinfo(hndl, RTLD_DI_LINKMAP, &lmap) != 0) {
+        set_errmsg("dlinfo error");
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    return plthook_open_real(plthook_out, (const char*)lmap->l_addr, lmap->l_name);
+}
+
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
     Dl_info info;

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -60,6 +60,7 @@
 
 #if defined __linux__
 #define ELF_OSABI     ELFOSABI_SYSV
+#define ELF_OSABI_ALT ELFOSABI_LINUX
 #elif defined __sun
 #define ELF_OSABI     ELFOSABI_SOLARIS
 #elif defined __FreeBSD__
@@ -543,8 +544,15 @@ static int check_elf_header(const Elf_Ehdr *ehdr)
         return PLTHOOK_INVALID_FILE_FORMAT;
     }
     if (ehdr->e_ident[EI_OSABI] != ELF_OSABI) {
+#ifdef ELF_OSABI_ALT
+        if (ehdr->e_ident[EI_OSABI] != ELF_OSABI_ALT) {
+            set_errmsg("invalid OS ABI: 0x%02x", ehdr->e_ident[EI_OSABI]);
+            return PLTHOOK_INVALID_FILE_FORMAT;
+        }
+#else
         set_errmsg("invalid OS ABI: 0x%02x", ehdr->e_ident[EI_OSABI]);
         return PLTHOOK_INVALID_FILE_FORMAT;
+#endif
     }
     if (ehdr->e_type != ET_EXEC && ehdr->e_type != ET_DYN) {
         set_errmsg("invalid file type: 0x%04x", ehdr->e_type);

--- a/plthook_osx.c
+++ b/plthook_osx.c
@@ -142,6 +142,15 @@ int plthook_open(plthook_t **plthook_out, const char *filename)
     return plthook_open_real(plthook_out, _dyld_get_image_header(idx));
 }
 
+int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
+{
+    if (hndl == NULL) {
+        set_errmsg("NULL handle");
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    return plthook_open_real(plthook_out, (const struct mach_header *)hdnl);
+}
+
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
     Dl_info dlinfo;

--- a/plthook_win32.c
+++ b/plthook_win32.c
@@ -93,6 +93,15 @@ int plthook_open(plthook_t **plthook_out, const char *filename)
     return plthook_open_real(plthook_out, hMod);
 }
 
+int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
+{
+    if (hndl == NULL) {
+        set_errmsg("NULL handle");
+        return PLTHOOK_FILE_NOT_FOUND;
+    }
+    return plthook_open_real(plthook_out, (HMODULE)hndl);
+}
+
 int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
     HMODULE hMod;


### PR DESCRIPTION
Hi there, I have a program that does function interception for capturing OpenGL, and I typically do this just via `LD_PRELOAD`. I found after a long investigation that one program was failing to be intercepted because it was loading a library with `RTLD_DEEPBIND`. plthook helps with catching that case and fixing it up so I can still hook.

I've included here the minor changes I made just in case you are interested to see them - please feel no obligation to take them upstream, as I've only verified them for my niche use-case so there might be impacts I'm not aware of.
1. I added a conditional `extern "C"` around the header exports, so I could call the functions from C++ without having linker errors.
2. I added a function `plthook_open_by_handle` since I am calling plthook from inside `dlopen()`. This expects to take either the `void*` from `dlopen()` on linux, or the `HMODULE` from equivalent functions on windows, or a `struct mach_header *` on osx. I'm not sure if the osx one makes sense, I don't code on apple. I thought it was a sane default though.
3. With my testing I encountered a binary with the OS ABI set to GNU or Linux - 0x03. As far as I understand it, this indicates GNU extensions to the SysV ABI. I couldn't find clearly documented what the changes are, but it seems at least to me like it's compatible enough that plthook still works.
