### PR TITLE
fix crash when write GOT if library was built with "-z relro" but not…

### DIFF
--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -708,15 +708,12 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
     }
 
 #ifdef SUPPORT_RELRO
-    dyn = find_dyn_by_tag(lmap->l_ld, DT_FLAGS_1);
-    if (dyn != NULL && (dyn->d_un.d_val & DF_1_NOW)) {
-        int rv = set_relro_members(&plthook, lmap);
-        if (rv != 0) {
-            return rv;
-        }
-        if (page_size == 0) {
-            page_size = sysconf(_SC_PAGESIZE);
-        }
+    int rv = set_relro_members(&plthook, lmap);
+    if (rv != 0) {
+        return rv;
+    }
+    if (page_size == 0) {
+        page_size = sysconf(_SC_PAGESIZE);
     }
 #endif
 


### PR DESCRIPTION
… "-z now"

- library could be built in gcc only with "-Wl,-z,relro" without "-Wl,-z,now", so that the library has RELRO enabled but the "BIND_NOW" won't present in the .dyn section. plthook should handle this usage case.