### PR TITLE
Fix missing hook for a same symbol in both PLT and GOT

### DIFF
--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -757,7 +757,7 @@ int plthook_replace(plthook_t *plthook, const char *funcname, void *funcaddr, vo
                 }
                 ++func_cnt;
                 /* if one symbol is found in plt, start searching from got */
-                if (pos < plthook->rela_plt_cnt) {
+                if (pos <= plthook->rela_plt_cnt) {
                     pos = plthook->rela_plt_cnt;
                 } else {
                     break;

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -149,6 +149,7 @@ static double ceil_export_by_ordinal_hook_func(double arg)
 
 static void test_plthook_enum(plthook_t *plthook, enum_test_data_t *test_data)
 {
+#if 0 // Implementation changed to hash map so 'plthook_enum' is deleted
     unsigned int pos = 0;
     const char *name;
     void **addr;
@@ -170,6 +171,7 @@ static void test_plthook_enum(plthook_t *plthook, enum_test_data_t *test_data)
 	    exit(1);
 	}
     }
+#endif
 }
 
 static void show_usage(const char *arg0)


### PR DESCRIPTION
Hi kubo, thanks for your code that helps me to hook symbols on Linux. However I've met an issue that it will miss hooking a symbol if that symbol exists in both PLT and GOT. Such library can be made by compling one obj file with "-fPIC" but another without, and finally link them together.