### PR TITLE
uClibc support

### DIFF
--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -62,6 +62,10 @@
 #include <link.h>
 #include "plthook.h"
 
+#if defined __UCLIBC__ && !defined RTLD_NOLOAD
+#define RTLD_NOLOAD 0
+#endif
+
 #ifndef __GNUC__
 #define __attribute__(arg)
 #endif
@@ -200,7 +204,7 @@ static int check_elf_header(const Elf_Ehdr *ehdr);
 #endif
 static void set_errmsg(const char *fmt, ...) __attribute__((__format__ (__printf__, 1, 2)));
 
-#if defined __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
 struct dl_iterate_data {
     char* addr;
     struct link_map lmap;
@@ -245,7 +249,7 @@ int plthook_open(plthook_t **plthook_out, const char *filename)
 
 int plthook_open_by_handle(plthook_t **plthook_out, void *hndl)
 {
-#if defined __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
     char *addr;
 
     if (hndl == NULL) {
@@ -276,7 +280,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
 {
 #if defined __FreeBSD__
     return PLTHOOK_NOT_IMPLEMENTED;
-#elif defined __ANDROID__
+#elif defined __ANDROID__ || defined __UCLIBC__
     struct dl_iterate_data data = {0,};
     data.addr = address;
     dl_iterate_phdr(dl_iterate_cb, &data);
@@ -300,7 +304,7 @@ int plthook_open_by_address(plthook_t **plthook_out, void *address)
 
 static int plthook_open_executable(plthook_t **plthook_out)
 {
-#if defined __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
     return plthook_open_shared_library(plthook_out, NULL);
 #elif defined __linux__
     return plthook_open_real(plthook_out, _r_debug.r_map);
@@ -339,7 +343,7 @@ static int plthook_open_executable(plthook_t **plthook_out)
 static int plthook_open_shared_library(plthook_t **plthook_out, const char *filename)
 {
     void *hndl = dlopen(filename, RTLD_LAZY | RTLD_NOLOAD);
-#ifdef __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
     int rv;
 #else
     struct link_map *lmap = NULL;
@@ -349,7 +353,7 @@ static int plthook_open_shared_library(plthook_t **plthook_out, const char *file
         set_errmsg("dlopen error: %s", dlerror());
         return PLTHOOK_FILE_NOT_FOUND;
     }
-#ifdef __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
     rv = plthook_open_by_handle(plthook_out, hndl);
     dlclose(hndl);
     return rv;
@@ -541,7 +545,7 @@ static int plthook_open_real(plthook_t **plthook_out, struct link_map *lmap)
 
 #if defined __linux__
     plthook.plt_addr_base = (char*)lmap->l_addr;
-#if defined __ANDROID__
+#if defined __ANDROID__ || defined __UCLIBC__
     dyn_addr_base = (const char*)lmap->l_addr;
 #endif
 #elif defined __FreeBSD__ || defined __sun

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -10,6 +10,10 @@
 #include <dlfcn.h>
 #endif
 
+#if defined __UCLIBC__ && !defined RTLD_NOLOAD
+#define RTLD_NOLOAD 0
+#endif
+
 #define CHK_PH(func) do { \
     if (func != 0) { \
         fprintf(stderr, "%s error: %s\n", #func, plthook_error()); \

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -206,7 +206,7 @@ static void test_plthook_enum(plthook_t *plthook, enum_test_data_t *test_data)
 
 static void show_usage(const char *arg0)
 {
-    fprintf(stderr, "Usage: %s (open | open_by_handle)\n", arg0);
+    fprintf(stderr, "Usage: %s (open | open_by_handle | open_by_address)\n", arg0);
 }
 
 static void hook_function_calls_in_executable(enum open_mode open_mode)


### PR DESCRIPTION
uClibc doesn't implement the dlinfo() and dladdr1() dl functions.
The existing Android solution fits for the uClibc case as well.

I’ve ran the test program locally when compiling with uClibc toolchain grabbed from: https://toolchains.bootlin.com.

I'll be happy if you can add the uClibc toolchain to the Travis CI system as well.