### PR TITLE
Remove redundant semi colon on extern c

### DIFF
--- a/plthook.h
+++ b/plthook.h
@@ -60,7 +60,7 @@ void plthook_close(plthook_t *plthook);
 const char *plthook_error(void);
 
 #ifdef __cplusplus
-}; /* extern "C" */
+} /* extern "C" */
 #endif
 
 #endif


### PR DESCRIPTION
No semi colon is necessary when using extern c 
Fixes compilation using gcc 9.3.0 when using -Werror=pedantic "error: extra ‘;’"
https://en.cppreference.com/w/cpp/language/language_linkage