### PR TITLE
Add loongarch64 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -127,7 +127,9 @@ jobs:
     - name: riscv64-linux-gnu with optimization
       run: |
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
-
+    - name: loongarch64-linux-gnu without optimization
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=-14
   tests_on_macos:
     name: Tests on macOS
     if: github.event.inputs.tests_on_macos == 'true' || github.event.inputs.tests_on_macos == ''

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -73,7 +73,7 @@ jobs:
         ./uclibc-test.sh i686
 
   tests_on_qemu:
-    name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le and riscv64)
+    name: Tests on Qemu (arm, armhf, arm64, ppc, ppc64le, riscv64 and loongarch64)
     if: github.event.inputs.tests_on_qemu == 'true' || github.event.inputs.tests_on_qemu == ''
     runs-on: ubuntu-latest
     defaults:
@@ -84,7 +84,7 @@ jobs:
     - name: Install packages
       run: |
         sudo apt update
-        sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross
+        sudo apt install -y qemu-user gcc-arm-linux-gnueabi gcc-arm-linux-gnueabihf gcc-aarch64-linux-gnu gcc-powerpc-linux-gnu gcc-powerpc64le-linux-gnu gcc-riscv64-linux-gnu gcc-14-loongarch64-linux-gnu libc6-dev-armhf-cross libc6-dev-ppc64el-cross libc6-dev-powerpc-cross libc6-dev-armel-cross libc6-dev-arm64-cross
     - name: arm-linux-gnueabi without optimization
       run: |
         make relro_pie_tests TARGET_PLATFORM=arm-linux-gnueabi
@@ -103,6 +103,9 @@ jobs:
     - name: riscv64-linux-gnu without optimization
       run: |
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
+    - name: loongarch64-linux-gnu without optimization
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64
     - name: set OPT_CLFAGS
       run: |
         echo OPT_CFLAGS=-O3 >> $GITHUB_ENV
@@ -124,6 +127,9 @@ jobs:
     - name: riscv64-linux-gnu with optimization
       run: |
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
+    - name: loongarch64-linux-gnu with optimization
+      run: |
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64
 
   tests_on_macos:
     name: Tests on macOS

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -127,9 +127,6 @@ jobs:
     - name: riscv64-linux-gnu with optimization
       run: |
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
-    - name: loongarch64-linux-gnu with optimization
-      run: |
-        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=-14
 
   tests_on_macos:
     name: Tests on macOS

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -105,7 +105,7 @@ jobs:
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
     - name: loongarch64-linux-gnu without optimization
       run: |
-        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=-14
     - name: set OPT_CLFAGS
       run: |
         echo OPT_CFLAGS=-O3 >> $GITHUB_ENV
@@ -129,7 +129,7 @@ jobs:
         make relro_pie_tests TARGET_PLATFORM=riscv64-linux-gnu QEMU_ARCH=riscv64
     - name: loongarch64-linux-gnu with optimization
       run: |
-        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64
+        make relro_pie_tests TARGET_PLATFORM=loongarch64-linux-gnu QEMU_ARCH=loongarch64 GCC_VERSION=-14
 
   tests_on_macos:
     name: Tests on macOS

--- a/plthook_elf.c
+++ b/plthook_elf.c
@@ -107,6 +107,9 @@
 #else
 #error unsupported RISCV implementation
 #endif
+#elif defined __loongarch64
+#define R_JUMP_SLOT   R_LARCH_JUMP_SLOT
+#define R_GLOBAL_DATA R_LARCH_64
 #elif 0 /* disabled because not tested */ && (defined __sparcv9 || defined __sparc_v9__)
 #define R_JUMP_SLOT   R_SPARC_JMP_SLOT
 #elif 0 /* disabled because not tested */ && (defined __sparc || defined __sparc__)

--- a/test/Makefile
+++ b/test/Makefile
@@ -60,8 +60,8 @@ all: libtest.$(SOEXT) testprog$(EXEEXT)
 libtest.$(SOEXT): libtest.c libtest.h
 	$(CC) $(CFLAGS_SHARED) $(CFLAGS) -DLIBTEST_DLL -o libtest.$(SOEXT) libtest.c -lm
 
-testprog$(EXEEXT): testprog.c ../$(PLTHOOK_C) libtest.h
-	$(CC) $(CFLAGS_EXE) $(CFLAGS) -o testprog$(EXEEXT) -I.. testprog.c ../$(PLTHOOK_C) -L. -ltest $(LIBS)
+testprog$(EXEEXT): testprog.c testlazybinding.c ../$(PLTHOOK_C) libtest.h
+	$(CC) $(CFLAGS_EXE) $(CFLAGS) -o testprog$(EXEEXT) -I.. testprog.c ../$(PLTHOOK_C) testlazybinding.c -L. -ltest $(LIBS)
 
 run_tests: clean libtest.$(SOEXT) testprog$(EXEEXT)
 	LD_LIBRARY_PATH=. $(KICK_CMD) ./testprog$(EXEEXT) open

--- a/test/Makefile
+++ b/test/Makefile
@@ -18,7 +18,7 @@ ifeq ($(UNAME_S),Linux)
   # Linux
   TESTS = relro_pie_tests
   ifneq ($(TARGET_PLATFORM),)
-    CC = $(TARGET_PLATFORM)-gcc
+    CC = $(TARGET_PLATFORM)-gcc$(GCC_VERSION)
     KICK_CMD = qemu-$(or $(QEMU_ARCH),$(shell echo $(TARGET_PLATFORM) | sed -e 's/-.*//')) -L /usr/$(TARGET_PLATFORM)
   endif
 endif

--- a/test/Makefile.win32
+++ b/test/Makefile.win32
@@ -6,8 +6,8 @@ all: libtest.dll testprog.exe
 libtest.dll: libtest.c libtest.h
 	cl /nologo $(DLL_CFLAGS) /DLIBTEST_DLL /Felibtest.dll libtest.c /link /def:libtest.def
 
-testprog.exe: testprog.c ../plthook_win32.c libtest.h
-	cl /nologo $(EXE_CFLAGS) /Fetestprog -I.. testprog.c ..\plthook_win32.c libtest.lib
+testprog.exe: testprog.c testlazybinding.c ../plthook_win32.c libtest.h
+	cl /nologo $(EXE_CFLAGS) /Fetestprog -I.. testprog.c testlazybinding.c ..\plthook_win32.c libtest.lib
 
 check: libtest.dll testprog.exe
 	.\testprog.exe open

--- a/test/testlazybinding.c
+++ b/test/testlazybinding.c
@@ -1,0 +1,7 @@
+#include "libtest.h"
+#include <stddef.h>
+double lazy_binding_call()
+{
+    double num = strtod_cdecl("3.7", NULL);
+    return num;
+}

--- a/test/testprog.c
+++ b/test/testprog.c
@@ -291,6 +291,7 @@ static void hook_function_calls_in_library(enum open_mode open_mode)
     plthook_close(plthook);
 }
 
+double lazy_binding_call();
 int main(int argc, char **argv)
 {
     double expected_result = strtod("3.7", NULL);
@@ -312,7 +313,8 @@ int main(int argc, char **argv)
     }
 
     /* Resolve the function addresses by lazy binding. */
-    strtod_cdecl("3.7", NULL);
+    lazy_binding_call();
+    //double num = strtod_cdecl("3.7", NULL);
 #if defined _WIN32 || defined __CYGWIN__
     strtod_stdcall("3.7", NULL);
     strtod_fastcall("3.7", NULL);


### PR DESCRIPTION
This pull request add LoongArch64 support.
- There no default gcc version for this architecture in the test system, we have to explicit  gcc  version
- when enable optimization with -O2+, the last test `check Partial RELRO + -fno-plt ` will failure (same with aarch64), need more investigation figure out it.